### PR TITLE
Update web-vitals.js to v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+### 2024-07-12
+
+- Update web-vitals.js to version 4, in case the library is loaded from the unpkg.com domain and removed FID from the Tag Template ([#8](https://github.com/google-marketing-solutions/web-vitals-gtm-template/pull/8)).
+
+Make sure to rename your dataLayer variables in your Google Tag Manager container based on the [upgrading to v4 documentation list](https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v4.md). New features have also been [added](https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v4.md#-new-features) to v4 that are available in the dataLayer of Google Tag Manager.
+
+### 2024-04-10
+
+- Adding automation ([#7](https://github.com/google-marketing-solutions/web-vitals-gtm-template/pull/7)). 
+
+### 2024-12-15
+
+- Initial release.

--- a/template.tpl
+++ b/template.tpl
@@ -229,7 +229,7 @@ const Object = require('Object');
 const log = require('logToConsole');
 
 // Variables storing information from user input.
-const packageBuild = (data.build === 'standard') ? 'https://unpkg.com/web-vitals@3/dist/web-vitals.iife.js' : 'https://unpkg.com/web-vitals@3/dist/web-vitals.attribution.iife.js';
+const packageBuild = (data.build === 'standard') ? 'https://unpkg.com/web-vitals@4/dist/web-vitals.iife.js' : 'https://unpkg.com/web-vitals@4/dist/web-vitals.attribution.iife.js';
 const libraryUrl = data.customURL || packageBuild;
 const measureAllMetrics = data.metrics === 'allMetrics';
 const dataLayerName = 'dataLayer';

--- a/template.tpl
+++ b/template.tpl
@@ -139,13 +139,6 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "type": "CHECKBOX",
-        "name": "fid",
-        "checkboxText": "FID",
-        "simpleValueType": true,
-        "help": "First Input Delay (FID) measures the time from when a user first interacts with the site to the time when the browser is able to respond to that interaction."
-      },
-      {
-        "type": "CHECKBOX",
         "name": "cls",
         "checkboxText": "CLS",
         "simpleValueType": true,
@@ -268,7 +261,6 @@ const loadwebVitals = () => {
   if (webVitalsGlobal && typeof webVitalsGlobal === 'object') {
     if (data.cls || data.metrics === 'allMetrics') webVitalsGlobal.onCLS(pushData);
     if (data.fcp || data.metrics === 'allMetrics') webVitalsGlobal.onFCP(pushData);
-    if (data.fid || data.metrics === 'allMetrics') webVitalsGlobal.onFID(pushData);
     if (data.inp || data.metrics === 'allMetrics') webVitalsGlobal.onINP(pushData);
     if (data.lcp || data.metrics === 'allMetrics') webVitalsGlobal.onLCP(pushData);
     if (data.ttfb || data.metrics === 'allMetrics') webVitalsGlobal.onTTFB(pushData);


### PR DESCRIPTION
Update web-vitals.js to version 4, in case the library is loaded from the unpkg.com domain ([see Tag Setup](https://github.com/google-marketing-solutions/web-vitals-gtm-template?tab=readme-ov-file#tag-setup)).

- Changes coming with version 4: https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md
- This PR takes the [upgrading to v4 documentation](https://github.com/GoogleChrome/web-vitals/blob/main/docs/upgrading-to-v4.md) into consideration